### PR TITLE
Re-enable git-hound

### DIFF
--- a/home-manager/roles/red/default.nix
+++ b/home-manager/roles/red/default.nix
@@ -111,7 +111,7 @@
         ghdorker
         ghidra
         girsh
-        #git-hound https://github.com/NixOS/nixpkgs/issues/276787
+        git-hound
         gitleaks
         go-cve-search
         gobuster


### PR DESCRIPTION
`git-hound` was updated to the latest upstream release