### PR TITLE
Update flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
           ./nixos/. # It refers to the default.nix at nixos/ directory that imports in chain all the subfolder contents containing default.nix
           ./nixos/hosts/software
           ./nixos/modules/boot/${bootloader}
-          ./nixos/modules/desktops/${desktop}
+          ./nixos/home-manager/desktops/${desktop}
           ./nixos/modules/dms/${dmanager}
           ./nixos/modules/themes/${theme}
           ./nixos/home-manager/terminals/${terminal}


### PR DESCRIPTION
Implement fix to locate the desktop options in the home-manager folder, as it is not in the modules folder any longer.