### PR TITLE
Fix warnings shown during cyber roles switch

### DIFF
--- a/nixos/home-manager/shells/zsh/default.nix
+++ b/nixos/home-manager/shells/zsh/default.nix
@@ -19,7 +19,7 @@ in
       home.file.".zshrc".source = ./zshrc;
       programs.zsh = {
         enable = true;
-        enableAutosuggestions = true;
+        autosuggestion.enable = true;
         enableCompletion = true;
         syntaxHighlighting.enable = true;
         /*shellAliases = {

--- a/nixos/modules/hardware/default.nix
+++ b/nixos/modules/hardware/default.nix
@@ -17,7 +17,7 @@
     hardware.bolt.enable = true;
     printing.enable = false;
     timesyncd.enable = true;
-    xserver.libinput.enable = true;
+    libinput.enable = true;
   };
   zramSwap.enable = true; # To not change upstream! It is managed by the installer
   hardware = {


### PR DESCRIPTION
Fix warnings by renaming options that had old names.

```nix
trace: warning: athena profile: The option programs.zsh.enableAutosuggestions' defined in /etc/nixos/home-manager/shells/zsh' has been renamed to programs.zsh.autosuggestion.enable'.
trace: warning: The option services.xserver.libinput.enable' defined in /etc/nixos/modules/hardware' has been renamed to services.libinput.enable'.
```