### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/docs/nix.md
+++ b/docs/nix.md
@@ -433,7 +433,7 @@ home.packages = [
 ```
 HM usually adds a custom shell script sourced by your shell to set environment variables, so you need to manage your shell via HM with programs.name.enable. This means that env variables only will be visible to child processes of the shell, not graphical applications started from your launcher.
 
-Note that the wiki at https://nixos.wiki is unofficial and has a lot of wrong things, so don't follow it.
+Note that the wiki at https://wiki.nixos.org is unofficial and has a lot of wrong things, so don't follow it.
 
 The official docs are [here](https://nixos.org/learn).
 

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -433,7 +433,7 @@ home.packages = [
 ```
 HM usually adds a custom shell script sourced by your shell to set environment variables, so you need to manage your shell via HM with programs.name.enable. This means that env variables only will be visible to child processes of the shell, not graphical applications started from your launcher.
 
-Note that the wiki at https://wiki.nixos.org is unofficial and has a lot of wrong things, so don't follow it.
+Note that the wiki at https://nixos.wiki unofficial and has a lot of wrong things, so don't follow it. There is also an official wiki at https://wiki.nixos.
 
 The official docs are [here](https://nixos.org/learn).
 


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️