### PR TITLE
error: nerdfonts has been separated into individual font packages und…

### DIFF
--- a/nixos/home-manager/desktops/axyl/default.nix
+++ b/nixos/home-manager/desktops/axyl/default.nix
@@ -6,7 +6,9 @@ let
     liberation_ttf
     source-code-pro
     inter
-    (nerdfonts.override { fonts = [ "JetBrainsMono" "NerdFontsSymbolsOnly" "Iosevka" ]; })
+    nerd-fonts.jetbrains-mono
+    nerd-fonts.symbols-only
+    nerd-fonts.iosevka
   ];
 
   bspwm-packages = with pkgs; [

--- a/nixos/home-manager/desktops/bspwm-critical/default.nix
+++ b/nixos/home-manager/desktops/bspwm-critical/default.nix
@@ -1,7 +1,8 @@
 { lib, pkgs, config, ... }:
 let
   fontList = with pkgs; [
-    (nerdfonts.override { fonts = [ "JetBrainsMono" "NerdFontsSymbolsOnly" ]; })
+    nerd-fonts.jetbrains-mono
+    nerd-fonts.symbols-only
   ];
 
   bspwm-packages = with pkgs; [

--- a/nixos/home-manager/desktops/bspwm/default.nix
+++ b/nixos/home-manager/desktops/bspwm/default.nix
@@ -1,7 +1,10 @@
 { lib, pkgs, config, ... }:
 let
   fontList = with pkgs; [
-    (nerdfonts.override { fonts = [ "JetBrainsMono" "NerdFontsSymbolsOnly" "FiraCode" "Hack" ]; })
+    nerd-fonts.jetbrains-mono
+    nerd-fonts.symbols-only
+    nerd-fonts.fira-code
+    nerd-fonts.hack
   ];
 
   bspwm-packages = with pkgs; [

--- a/nixos/home-manager/desktops/cinnamon/default.nix
+++ b/nixos/home-manager/desktops/cinnamon/default.nix
@@ -10,7 +10,8 @@ let
   ];
 
   fontList = with pkgs; [
-    (nerdfonts.override { fonts = [ "JetBrainsMono" "NerdFontsSymbolsOnly" ]; })
+    nerd-fonts.jetbrains-mono
+    nerd-fonts.symbols-only
   ];
 
   gtkTheme = "${config.athena.theme-components.gtk-theme}";

--- a/nixos/home-manager/desktops/gnome/default.nix
+++ b/nixos/home-manager/desktops/gnome/default.nix
@@ -16,7 +16,8 @@ let
   backgroundTheme = "${config.athena.theme-components.background}";
 
   fontList = with pkgs; [
-    (nerdfonts.override { fonts = [ "JetBrainsMono" "NerdFontsSymbolsOnly" ]; })
+    nerd-fonts.jetbrains-mono
+    nerd-fonts.symbols-only
   ];
 in {
   config = lib.mkIf (config.athena.desktopManager == "gnome") {

--- a/nixos/home-manager/desktops/kde/default.nix
+++ b/nixos/home-manager/desktops/kde/default.nix
@@ -30,7 +30,8 @@ let
     systemsettings
   ];
   fontList = with pkgs; [
-    (nerdfonts.override { fonts = [ "JetBrainsMono" "NerdFontsSymbolsOnly" ]; })
+    nerd-fonts.jetbrains-mono
+    nerd-fonts.symbols-only
   ];
 in {
   config = lib.mkIf (config.athena.desktopManager == "kde") {

--- a/nixos/home-manager/desktops/mate/default.nix
+++ b/nixos/home-manager/desktops/mate/default.nix
@@ -16,7 +16,8 @@
   ];
 
   fontList = with pkgs; [
-    (nerdfonts.override { fonts = [ "JetBrainsMono" "NerdFontsSymbolsOnly" ]; })
+    nerd-fonts.jetbrains-mono
+    nerd-fonts.symbols-only
   ];
 
   gtkTheme = "${config.athena.theme-components.gtk-theme}";

--- a/nixos/home-manager/desktops/xfce/xfce.nix
+++ b/nixos/home-manager/desktops/xfce/xfce.nix
@@ -24,7 +24,8 @@ in
   config = mkIf (cfg != null) (mkMerge [
     {
       home.packages = with pkgs; [
-        (nerdfonts.override { fonts = [ "JetBrainsMono" "NerdFontsSymbolsOnly" ]; })
+        nerd-fonts.jetbrains-mono
+        nerd-fonts.symbols-only
         #mugshot
         networkmanagerapplet # NetworkManager control applet for GNOME
         xdg-user-dirs # A tool to help manage well known user directories like the desktop folder and the music folder


### PR DESCRIPTION
Fix error:

"error: nerdfonts has been separated into individual font packages under the namespace nerd-fonts"

This error appends during installation and maybe during updating.

Root cause:

nerdfonts package has been split:

https://nixos.wiki/wiki/Fonts#Installing_specific_fonts_from_nerdfonts

https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=nerdfonts

https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=nerd-fonts