### PR TITLE
Replace gnome.nautilus with pkgs.nautilus

### DIFF
--- a/nixos/home-manager/desktops/xfce/xfce.nix
+++ b/nixos/home-manager/desktops/xfce/xfce.nix
@@ -115,7 +115,7 @@ in
     (mkIf cfg.refined rec {
       # If xfce refined is enabled
       home.packages = with pkgs; [
-        gnome.nautilus  
+        nautilus  
       ];
       xdg.configFile."xfce4" = {
         source = ./config/xfce4-refined;


### PR DESCRIPTION
The way of referencing the package has changed to pkgs.nautilus.